### PR TITLE
ci: Slight improvement

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,12 +15,13 @@ jobs:
 
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v2
+              uses: actions/checkout@v4
 
             - name: Set up NodeJS
-              uses: actions/setup-node@v3
+              uses: actions/setup-node@v4
               with:
                   node-version: 20
+                  registry-url: 'https://registry.npmjs.org'
 
             - name: Install dependencies
               run: npm install

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
             - name: Set up NodeJS
               uses: actions/setup-node@v4
               with:
-                  node-version: '20.x'
+                  node-version: 20
                   registry-url: 'https://registry.npmjs.org'
 
             - name: Ensure npm is at latest version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,33 @@
+name: Publish Package to npmjs
+
+on:
+    workflow_dispatch:
+
+jobs:
+    build:
+        runs-on: ubuntu-latest
+
+        permissions:
+            contents: read
+            id-token: write
+
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v4
+
+            - name: Set up NodeJS
+              uses: actions/setup-node@v4
+              with:
+                  node-version: '20.x'
+                  registry-url: 'https://registry.npmjs.org'
+
+            - name: Ensure npm is at latest version
+              run: npm install -g npm
+
+            - name: Clean Install dependencies
+              run: npm ci
+
+            - name: Publish to npm
+              run: npm publish --provenance
+                  env:
+                      NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -2,8 +2,7 @@
 
 A simple JavaScript library to execute code on specific dates
 
-> [!NOTE]
->
+> NOTE
 > This library is **fully** compatible with browsers
 
 ## ⚙️ Installation


### PR DESCRIPTION
This PR remove GitHub flavoured markdown since those won't be rendered in [npmjs](https://www.npmjs.com/package/datetrigger).

This PR also update actions to v4 migrating to Node 20, and introduce a Publish CI that publish to NPM with Provenance when it's triggered.

> [!CAUTION]
> Require setting up **NPM_TOKEN** secret for publish CI to work.